### PR TITLE
Fix Error Handling of Call to CertOpenSystemStoreA

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,13 +171,12 @@ typedef struct _CERT_CONTEXT {
       options.maxcerts = 300;
     }
     
-    var hStoreHandle = null;
+    const hStoreHandle = Crypto.CertOpenSystemStoreA(null, StoreName);
     var pCertContext = null;   
-    if (hStoreHandle = Crypto.CertOpenSystemStoreA(null, StoreName)){
+    if (!ref.isNull(hStoreHandle)){
       //console.log("The "+StoreName+" store has been opened as ", hStoreHandle);
     } else {
-      console.log("The "+StoreName+" store failed to open.");
-      return [];
+      throw new Error('The '+StoreName+' store failed to open.');
     }
     
     var maxcerts = options.maxcerts;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-windows-root-certs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Enables read of windows root certificates using ffi, and patching of node to use them",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi!

I came across a problem when using your library in a web server running inside of iisnode. It turns out that by default the IIS application pool identity is configured to not load a user profile. Therefore it is unable to access the certificate store. Since the error of *Crypt32* is not handled properly, it causes the node process to crash without any error message in a subsequent ffi-call. This PR attempts to fix that behaviour:

*CertOpenSystemStoreA* returns null when it fails (see [here](https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certopensystemstorea#return-value)). As stated before, this can e.g. be due to insufficient access rights to the certificate store. However, *ffi* returns a buffer whose truthiness will always be true. To properly catch the error and prevent the application from crashing, we need to check for null using the *ref* package as done with the other call to *Crypt32*.

My changes avoid application crashes. However, I think we should actually throw an appropriate error that can be handled by the application that uses the library. I'm happy to add that. Just let me know your thoughts!

Greetings,
Fabian